### PR TITLE
Use javax.validation annotations

### DIFF
--- a/common/parser/parser.go
+++ b/common/parser/parser.go
@@ -279,7 +279,7 @@ func getAttributes(c *xmlquery.Node) []types.Attribute {
 		attrib.Name = replaceNO(a.SelectAttr("name"))
 		attrib.Deprecated = a.SelectElement("tags/tag[@name='DEPRECATED']") != nil
 		attrib.List = strings.Compare(a.SelectElement("bounds").SelectAttr("upper"), "*") == 0
-		attrib.Optional = !attrib.List && strings.Compare(a.SelectElement("bounds").SelectAttr("lower"), "0") == 0
+		attrib.Optional = strings.Compare(a.SelectElement("bounds").SelectAttr("lower"), "0") == 0
 		attrib.Type = replaceNO(a.SelectElement("properties").SelectAttr("type"))
 
 		attributes = append(attributes, attrib)

--- a/generate/generator.go
+++ b/generate/generator.go
@@ -38,6 +38,13 @@ var funcMap = template.FuncMap{
 		return s
 	},
 	"javaType": types.GetJavaType,
+	"validFilt": func(t string, s string) string {
+		_, ok := types.JAVA_TYPE_MAP[t]
+		if ok {
+			return s
+		}
+		return `@Valid ` + s
+	},
 	"csType": func(s string, opt bool) string {
 		typ := types.GetCSType(s)
 		if opt && types.IsValueType(typ) {

--- a/generate/java/java_class_tpl.go
+++ b/generate/java/java_class_tpl.go
@@ -8,7 +8,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-import lombok.NonNull;
+import javax.validation.constraints.NotNull;
 import java.util.List;
 import no.fint.model.{{ javaType .Stereotype }};
 {{- if .Imports -}}
@@ -45,7 +45,7 @@ public {{- if .Abstract }} abstract {{- end }} class {{ .Name }} {{ if .Extends 
     @Deprecated
     {{- end }}
     {{- if not $att.Optional }}
-    @NonNull
+    @NotNull
     {{- end }}
     private {{ javaType $att.Type | listFilt $att.List }} {{ $att.Name }};
     {{- end }}

--- a/generate/java/java_class_tpl.go
+++ b/generate/java/java_class_tpl.go
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import java.util.List;
+import javax.validation.Valid;
 import javax.validation.constraints.*;
 import no.fint.model.{{ javaType .Stereotype }};
 {{- if .Imports -}}
@@ -47,6 +48,7 @@ public {{- if .Abstract }} abstract {{- end }} class {{ .Name }} {{ if .Extends 
     {{- if not $att.Optional }}
     {{ if $att.List }}@NotEmpty{{ else if eq "string" $att.Type }}@NotBlank{{ else }}@NotNull{{ end }}
     {{- end }}
+    @Valid
     private {{ javaType $att.Type | listFilt $att.List }} {{ $att.Name }};
     {{- end }}
 {{- end }}

--- a/generate/java/java_class_tpl.go
+++ b/generate/java/java_class_tpl.go
@@ -48,8 +48,7 @@ public {{- if .Abstract }} abstract {{- end }} class {{ .Name }} {{ if .Extends 
     {{- if not $att.Optional }}
     {{ if $att.List }}@NotEmpty{{ else if eq "string" $att.Type }}@NotBlank{{ else }}@NotNull{{ end }}
     {{- end }}
-    @Valid
-    private {{ javaType $att.Type | listFilt $att.List }} {{ $att.Name }};
+    private {{ javaType $att.Type | validFilt $att.Type | listFilt $att.List }} {{ $att.Name }};
     {{- end }}
 {{- end }}
 }

--- a/generate/java/java_class_tpl.go
+++ b/generate/java/java_class_tpl.go
@@ -8,8 +8,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-import javax.validation.constraints.NotNull;
 import java.util.List;
+import javax.validation.constraints.*;
 import no.fint.model.{{ javaType .Stereotype }};
 {{- if .Imports -}}
 {{ range $i := .Imports }}
@@ -45,7 +45,7 @@ public {{- if .Abstract }} abstract {{- end }} class {{ .Name }} {{ if .Extends 
     @Deprecated
     {{- end }}
     {{- if not $att.Optional }}
-    @NotNull
+    {{ if $att.List }}@NotEmpty{{ else if eq "string" $att.Type }}@NotBlank{{ else }}@NotNull{{ end }}
     {{- end }}
     private {{ javaType $att.Type | listFilt $att.List }} {{ $att.Name }};
     {{- end }}

--- a/generate/java/java_resource_class_tpl.go
+++ b/generate/java/java_resource_class_tpl.go
@@ -15,6 +15,7 @@ import lombok.ToString;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import javax.validation.Valid;
 import javax.validation.constraints.*;
 
 import no.fint.model.{{ javaType .Stereotype }};
@@ -63,6 +64,7 @@ public {{- if .Abstract }} abstract {{- end }} class {{ .Name }}Resource {{ if .
     {{- if not $att.Optional }}
     {{ if $att.List }}@NotEmpty{{ else if eq "string" $att.Type }}@NotBlank{{ else }}@NotNull{{ end }}
     {{- end }}
+    @Valid
     private {{ javaType $att.Type | resource $.Resources | listFilt $att.List }} {{ $att.Name }};
     {{- end }}
 

--- a/generate/java/java_resource_class_tpl.go
+++ b/generate/java/java_resource_class_tpl.go
@@ -10,12 +10,12 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import javax.validation.constraints.NotNull;
 import lombok.ToString;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import javax.validation.constraints.*;
 
 import no.fint.model.{{ javaType .Stereotype }};
 import no.fint.model.resource.FintLinks;
@@ -61,7 +61,7 @@ public {{- if .Abstract }} abstract {{- end }} class {{ .Name }}Resource {{ if .
     @Deprecated
     {{- end }}
     {{- if not $att.Optional }}
-    @NotNull
+    {{ if $att.List }}@NotEmpty{{ else if eq "string" $att.Type }}@NotBlank{{ else }}@NotNull{{ end }}
     {{- end }}
     private {{ javaType $att.Type | resource $.Resources | listFilt $att.List }} {{ $att.Name }};
     {{- end }}

--- a/generate/java/java_resource_class_tpl.go
+++ b/generate/java/java_resource_class_tpl.go
@@ -64,8 +64,7 @@ public {{- if .Abstract }} abstract {{- end }} class {{ .Name }}Resource {{ if .
     {{- if not $att.Optional }}
     {{ if $att.List }}@NotEmpty{{ else if eq "string" $att.Type }}@NotBlank{{ else }}@NotNull{{ end }}
     {{- end }}
-    @Valid
-    private {{ javaType $att.Type | resource $.Resources | listFilt $att.List }} {{ $att.Name }};
+    private {{ javaType $att.Type | resource $.Resources | validFilt $att.Type | listFilt $att.List }} {{ $att.Name }};
     {{- end }}
 
 {{- end }}

--- a/generate/java/java_resource_class_tpl.go
+++ b/generate/java/java_resource_class_tpl.go
@@ -10,7 +10,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.NonNull;
+import javax.validation.constraints.NotNull;
 import lombok.ToString;
 
 import java.util.Collections;
@@ -61,7 +61,7 @@ public {{- if .Abstract }} abstract {{- end }} class {{ .Name }}Resource {{ if .
     @Deprecated
     {{- end }}
     {{- if not $att.Optional }}
-    @NonNull
+    @NotNull
     {{- end }}
     private {{ javaType $att.Type | resource $.Resources | listFilt $att.List }} {{ $att.Name }};
     {{- end }}


### PR DESCRIPTION
Instead of `lombok.NonNull`, use `javax.validation.constraints.*`.  These make validation an optional action instead of the very explicit `NullPointerException`.

To validate data, use the following:

    ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
    Validator validator = factory.getValidator();
    Set<ConstraintViolation<Object>> violations = validator.validate(object);

The project needs the following dependencies:

    // Spring adds validation-api 1.x and hibernate-validator 5.x by default, all three dependencies needed to override.
    compile 'javax.validation:validation-api:2.0.1.Final'
    compile 'org.hibernate.validator:hibernate-validator:6.0.16.Final'
    compile 'org.hibernate.validator:hibernate-validator-annotation-processor:6.0.16.Final'
